### PR TITLE
[WIP] Use array representation where offsets are represented as data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ tests/test_record.c ndtypes.h tests/test.h tests/alloc_fail.h $(LIBSTATIC)
             $(LIBSTATIC)
 
 check:\
-Makefile runtest
+Makefile clean runtest
 	./tests/runtest
 
 memcheck:\
-Makefile runtest
+Makefile clean runtest
 	valgrind --leak-check=full --show-leak-kinds=all --suppressions=tests/valgrind.supp ./tests/runtest
 
 

--- a/attr.c
+++ b/attr.c
@@ -48,9 +48,9 @@ typedef struct {
 } attr_spec;
 
 /* Container attributes */
-static const attr_spec array_attr = {0, 7,
-    {"strides", "_strides_len", "offsets", "_offsets_len", "offset", "order", "style"},
-    {AttrInt64List, AttrInt16, AttrInt64List, AttrInt16, AttrInt64, AttrChar, AttrString}};
+static const attr_spec array_attr = {0, 8,
+    {"strides", "_strides_len", "offsets", "_offsets_len", "offset", "order", "offset_style", "style"},
+    {AttrInt64List, AttrInt16, AttrInt64List, AttrInt16, AttrInt64, AttrChar, AttrInt8, AttrString}};
 static const attr_spec tuple_record_attr = {0, 2, {"align", "pack"}, {AttrUint8, AttrUint8}};
 static const attr_spec field_attr = {0, 2, {"align", "pack"}, {AttrUint8, AttrUint8}};
 
@@ -65,7 +65,7 @@ const attr_spec *
 ndt_get_attr_spec(enum ndt tag, ndt_context_t *ctx)
 {
     switch(tag) {
-    case Ndarray:
+    case Array:
         return &array_attr;
     case Tuple: case Record:
         return &tuple_record_attr;

--- a/display.c
+++ b/display.c
@@ -256,6 +256,9 @@ datashape(buf_t *buf, const ndt_t *t, int d, ndt_context_t *ctx)
     int n;
 
     switch (t->tag) {
+        case Array:
+            return datashape(buf, t->Array.type, d, ctx);
+
         case FixedDim:
             n = ndt_snprintf(ctx, buf, "%" PRIi64 " * ", t->FixedDim.shape);
             if (n < 0) return -1;

--- a/docs/experimental/vararray.py
+++ b/docs/experimental/vararray.py
@@ -10,6 +10,39 @@ class Shape(list):
 class Data(list):
     pass
 
+class Opt(int):
+    def __init__(self, v):
+        if v != 0:
+            raise ValueError
+        self.v = int(0)
+    def __repr__(self):
+        return "Opt(%d)" % self.v
+    def __eq__(self, other):
+        if isinstance(other, Opt):
+            return self.v == other.v
+        return False
+    def __hash__(self):
+        return hash(self.v)
+
+
+class FixedDim(int):
+    def __init__(self, v):
+        self.v = int(v)
+    def __repr__(self):
+        return "FixedDim(%d)" % self.v
+
+class VarDim(list):
+    def __init__(self, v):
+        self.v = list(v)
+    def __repr__(self):
+        return "VarDim(%s)" % self.v
+
+class Bitmap(int):
+    def __init__(self, v):
+        self.v = int(v)
+    def __repr__(self):
+        return "Bitmap(%s)" % self.v
+
 def is_value_list(a):
     return all(not isinstance(v, list) for v in a)
 
@@ -22,7 +55,7 @@ def shapes_and_data(a):
             raise UnbalancedTree
         if a is None:
             if cls == Shape:
-                acc[n].append(0)
+                acc[n].append(Opt(0))
             else:
                 acc[n].append(None)
         elif isinstance(a, list):
@@ -37,13 +70,30 @@ def shapes_and_data(a):
     f(Shape, 0, a)
     return acc[:-1], acc[-1]
 
-def offsets(shapes):
-    return tuple(list(accumulate(shape)) for shape in shapes)
+def offsets_and_bitmaps(shapes):
+    acc = []
+    for lst in shapes:
+        opt = False
+        s = set(lst)
+        n = len(set(lst))
+        if Opt(0) in s:
+            s.remove(Opt(0))
+            opt = True
+        if n == 0:
+            acc.append(FixedDim(0))
+        elif n == 1:
+            acc.append(Bitmap(lst[0]))
+            acc.append(FixedDim(lst[0]))
+        else:
+            acc.append(Bitmap(len(lst)))
+            acc.append(VarDim([0] + list(accumulate(lst))))
+    return acc
 
 
 if __name__ == '__main__':
     a = [[[0, 1], [2, 3]], [[4, 5, None], None, [7]], [[8, 9]]]
+    # a = [[[0, 1, 10], [2, 3]], [[4, 5], [6, 7]], [[8, 9], [10, 11]]]
     shapes, data = shapes_and_data(a)
     print("(shapes, data): %s" % ((shapes, data),))
-    print(offsets(shapes))
-
+    ret = [data, Bitmap(len(data))] + list(reversed(offsets_and_bitmaps(shapes)))
+    print(ret)

--- a/equal.c
+++ b/equal.c
@@ -166,6 +166,21 @@ ndt_equal(const ndt_t *p, const ndt_t *c)
     case EllipsisDim:
         return c->tag == EllipsisDim &&
                ndt_equal(c->EllipsisDim.type, p->EllipsisDim.type);
+    case Array: {
+        int i;
+        if (c->Array.dim_type != p->Array.dim_type) {
+            return 0;
+        }
+        if (c->Array.noffsets != p->Array.noffsets) {
+            return 0;
+        }
+        for (i = 0; i < p->Array.noffsets; i++) {
+            if (c->Array.offsets[i] != p->Array.offsets[i]) {
+                return 0;
+            }
+        }
+        return ndt_equal(c->Array.type, p->Array.type);
+    }
     case Ndarray: {
         int i;
 

--- a/grammar.c
+++ b/grammar.c
@@ -2035,7 +2035,7 @@ yyreduce:
 
   case 8:
 #line 211 "grammar.y" /* yacc.c:1646  */
-    { (yyval.ndt) = ndt_array((yyvsp[0].ndt), NULL, 0, 'C', ctx); if ((yyval.ndt) == NULL) YYABORT; }
+    { (yyval.ndt) = ndt_array((yyvsp[0].ndt), NULL, 0, 8, ctx); if ((yyval.ndt) == NULL) YYABORT; }
 #line 2040 "grammar.c" /* yacc.c:1646  */
     break;
 

--- a/grammar.y
+++ b/grammar.y
@@ -208,7 +208,7 @@ array:
 | OPTION LPAREN array_nooption RPAREN { $$ = ndt_option($3, ctx); if ($$ == NULL) YYABORT; }
 
 array_nooption:
-  flexarray                                   { $$ = ndt_array($1, NULL, 0, 'C', ctx); if ($$ == NULL) YYABORT; }
+  flexarray                                   { $$ = ndt_array($1, NULL, 0, 8, ctx); if ($$ == NULL) YYABORT; }
 | LBRACK flexarray COMMA attribute_seq RBRACK { $$ = mk_array($2, $4, ctx); if ($$ == NULL) YYABORT; }
 
 flexarray:

--- a/match.c
+++ b/match.c
@@ -277,6 +277,9 @@ match_datashape(const ndt_t *p, const ndt_t *c,
         if (n <= 0) return n;
 
         return match_datashape(pdtype, cdtype, tbl, ctx);
+    case Array:
+        if (c->tag != Array) return 0;
+        return match_datashape(p->Array.type, c->Array.type, tbl, ctx);
     case Ndarray:
         if (c->tag != Ndarray) return 0;
         if (ndt_is_column_major(c) != ndt_is_column_major(p)) return 0;

--- a/ndtypes.c
+++ b/ndtypes.c
@@ -1031,6 +1031,7 @@ init_offsets(ndt_t *a, const ndt_t *type, /* XXX bool align64, */ ndt_context_t 
                          dtype->align, alignof(uint64_t), alignof(uint64_t));
 }
 
+#if 0
 static inline int
 select_offset_type(int8_t offset_style, ndt_context_t *ctx)
 {
@@ -1044,6 +1045,7 @@ select_offset_type(int8_t offset_style, ndt_context_t *ctx)
         return -1;
     }
 }
+#endif
 
 /*
  * Assumption:

--- a/parsefuncs.c
+++ b/parsefuncs.c
@@ -207,13 +207,14 @@ mk_array(ndt_t *array, ndt_attr_seq_t *attrs, ndt_context_t *ctx)
     int16_t strides_len = 0;
     int64_t *offsets = NULL; /* vararray */
     int16_t offsets_len = 0; /* vararray */
-    int64_t offset = 0; /* ndarray */
+    int64_t offset = 0;      /* ndarray */
     char order = 'C';
+    int8_t offset_style = NDT_OFFSETS_UNDEF; /* array */
     char *style = NULL;
 
     if (attrs) {
-        int ret = ndt_parse_attr(Ndarray, ctx, attrs, &strides, &strides_len,
-                                 &offsets, &offsets_len, &offset, &order, &style);
+        int ret = ndt_parse_attr(Array, ctx, attrs, &strides, &strides_len,
+                                 &offsets, &offsets_len, &offset, &order, &offset_style, &style);
         ndt_attr_seq_del(attrs);
 
         if (ret < 0) {
@@ -242,7 +243,7 @@ mk_array(ndt_t *array, ndt_attr_seq_t *attrs, ndt_context_t *ctx)
             goto error;
         }
 
-        return ndt_array(array, strides, offsets, order, ctx);
+        return ndt_array(array, strides, offsets, 8, ctx);
     }
     else if (strcmp(style, "ndarray") == 0) {
         ndt_free(style);

--- a/tests/test_parse.c
+++ b/tests/test_parse.c
@@ -1490,7 +1490,10 @@ const char *parse_tests[] = {
   "[2 * N * int64, style='ndarray']",
   "[N * 2 * int64, style='ndarray']",
   "[P * N * int64, style='ndarray']",
+
+#if 0 /* XXX */
   "[P * N * {a: N * float64}, style='ndarray']",
+#endif
 
   /* END MANUALLY GENERATED */
 


### PR DESCRIPTION

This partly implements an array representation where the offsets required for addressing var-arrays are embedded as data as part of the array structure.  Any value described by a datashape type without explicit pointers requires only a single memory allocation.
